### PR TITLE
Build packages with jpackage workflow error

### DIFF
--- a/qupath-extension-isyntax/build.gradle.kts
+++ b/qupath-extension-isyntax/build.gradle.kts
@@ -25,6 +25,12 @@ dependencies {
 }
 
 val platform = Utils.currentPlatform()
+val nativesClassifier = when (platform.classifier) {
+    "darwin-x86_64" -> "macos-x86_64"
+    "darwin-aarch64" -> "macos-aarch64"
+    "win32-x86_64" -> "windows-x86_64"
+    else -> platform.classifier
+}
 
 sourceSets {
     main {
@@ -144,7 +150,7 @@ val packageNative by tasks.registering(Copy::class) {
             include("**/libisyntax.so", "**/libisyntax.dylib", "**/isyntax.dll")
         }
     )
-    into("build/packaged-natives/natives/${platform.classifier}")
+    into("build/packaged-natives/natives/${nativesClassifier}")
 }
 
 tasks.processResources {

--- a/qupath-extension-isyntax/src/main/java/qupath/lib/images/servers/isyntax/jna/IsyntaxLoader.java
+++ b/qupath-extension-isyntax/src/main/java/qupath/lib/images/servers/isyntax/jna/IsyntaxLoader.java
@@ -75,7 +75,7 @@ public class IsyntaxLoader {
     private static File extractPackagedNative() throws IOException {
         List<String> platforms = detectPlatformClassifiers();
         for (String platform : platforms) {
-            String libName = platform.startsWith("windows") ? "isyntax.dll" : platform.startsWith("mac") ? "libisyntax.dylib" : "libisyntax.so";
+            String libName = platform.startsWith("windows") ? "isyntax.dll" : platform.startsWith("mac") || platform.startsWith("darwin") ? "libisyntax.dylib" : "libisyntax.so";
             String res = "/natives/" + platform + "/" + libName;
             try (InputStream in = IsyntaxLoader.class.getResourceAsStream(res)) {
                 if (in == null) continue;
@@ -108,6 +108,13 @@ public class IsyntaxLoader {
         variants.add(base.replace("linux-", "linux"));
         variants.add(base.replace("windows-", "windows"));
         variants.add(base.replace("macos-", "macos"));
+        // Add alternative classifier variants used by build tooling
+        if (base.startsWith("macos-")) {
+            variants.add(base.replace("macos-", "darwin-"));
+        }
+        if (base.startsWith("windows-")) {
+            variants.add(base.replace("windows-", "win32-"));
+        }
         return new ArrayList<>(variants);
     }
 


### PR DESCRIPTION
Align iSyntax native library packaging paths with loader search paths to resolve 'libisyntax not found' error on macOS.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bc32390-075f-4c89-8e22-2bd99aa29979">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bc32390-075f-4c89-8e22-2bd99aa29979">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

